### PR TITLE
CI: check errors of docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1076,6 +1076,7 @@ jobs:
 
       - name: Build Antora Docs
         run: |
+          set -xe
           cd doc
           bash ./build_antora.sh
 

--- a/doc/build_antora.sh
+++ b/doc/build_antora.sh
@@ -7,6 +7,8 @@
 # Official repository: https://github.com/boostorg/url
 #
 
+set -xe
+
 if [ $# -eq 0 ]
   then
     echo "No playbook supplied, using default playbook"


### PR DESCRIPTION
In Github Actions when building the docs, run `set -e`. The flag means if the script encounters an error it stops.  Usually that's what you want. To override it on a specific command use `command || true`.  By adding `set -e` we discover the docs builds have been failing recently, check the results of the previous workflow.