### PR TITLE
Fix/body avail assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ env:
   NET_RETRY_COUNT: 5
   DEFAULT_BUILD_VARIANT: debug,release
   UBSAN_OPTIONS: "print_stacktrace=1"
+  DEBIAN_FRONTEND: "noninteractive"
+  TZ: "Europe/London"
 
 jobs:
   runner-selection:
@@ -167,11 +169,10 @@ jobs:
             version: "*"
             cxx: "clang++"
             cc: "clang"
-            runs-on: "macos-11"
+            runs-on: "macos-14"
             b2-toolset: "clang"
             is-latest: true
-            is-earliest: true
-            name: "Apple-Clang"
+            name: "Apple-Clang (macOS 14)"
             build-type: "Release"
             build-cmake: true
 
@@ -179,10 +180,10 @@ jobs:
             version: "*"
             cxx: "clang++"
             cc: "clang"
-            runs-on: "macos-11"
+            runs-on: "macos-14"
             b2-toolset: "clang"
             is-latest: true
-            name: "Apple-Clang (ubsan)"
+            name: "Apple-Clang (macOS 14, ubsan)"
             build-type: "RelWithDebInfo"
             ubsan: true
 
@@ -190,44 +191,172 @@ jobs:
             version: "*"
             cxx: "clang++"
             cc: "clang"
-            runs-on: "macos-11"
+            runs-on: "macos-14"
             b2-toolset: "clang"
             is-latest: true
-            name: "Apple-Clang (asan)"
+            name: "Apple-Clang (macOS 14, asan)"
             build-type: "RelWithDebInfo"
             asan: true
+
+          - compiler: "apple-clang"
+            version: "*"
+            cxx: "clang++"
+            cc: "clang"
+            runs-on: "macos-13"
+            b2-toolset: "clang"
+            name: "Apple-Clang (macOS 13)"
+            build-type: "Release"
+
+          - compiler: "apple-clang"
+            version: "*"
+            cxx: "clang++"
+            cc: "clang"
+            runs-on: "macos-12"
+            b2-toolset: "clang"
+            name: "Apple-Clang (macOS 12)"
+            build-type: "Release"
 
           # Linux compilers
           #
 
           - compiler: "gcc"
-            version: "13"
+            version: "14"
             cxxstd: "17,20"
             latest-cxxstd: "20"
-            cxx: "g++-13"
-            cc: "gcc-13"
+            cxx: "g++-14"
+            cc: "gcc-14"
             runs-on: "ubuntu-latest"
-            container: "ubuntu:23.04"
+            container: "ubuntu:24.04"
             b2-toolset: "gcc"
             is-latest: true
-            name: "GCC 13: C++17-20"
+            name: "GCC 14: C++17-20"
             build-type: "Release"
             install: "zlib1g-dev"
             build-cmake: true
 
           - compiler: "gcc"
-            version: "13"
+            version: "14"
             cxxstd: "17,20"
             latest-cxxstd: "20"
-            cxx: "g++-13"
-            cc: "gcc-13"
+            cxx: "g++-14"
+            cc: "gcc-14"
             runs-on: "ubuntu-latest"
-            container: "ubuntu:23.04"
+            container: "ubuntu:24.04"
             b2-toolset: "gcc"
             is-latest: true
-            name: "GCC 13: C++17-20 (no zlib)"
+            name: "GCC 14: C++17-20 (no zlib)"
             build-type: "Release"
             build-cmake: true
+
+          - compiler: "gcc"
+            version: "14"
+            cxxstd: "17,20"
+            latest-cxxstd: "20"
+            cxx: "g++-14"
+            cc: "gcc-14"
+            runs-on: "ubuntu-latest"
+            container: "ubuntu:24.04"
+            b2-toolset: "gcc"
+            is-latest: true
+            name: "GCC 14: C++17-20 (x86)"
+            x86: true
+            build-type: "Release"
+            install: "gcc-14-multilib g++-14-multilib zlib1g-dev zlib1g-dev:i386"
+
+          - compiler: "gcc"
+            version: "14"
+            cxxstd: "17,20"
+            latest-cxxstd: "20"
+            cxx: "g++-14"
+            cc: "gcc-14"
+            runs-on: "ubuntu-latest"
+            container: "ubuntu:24.04"
+            b2-toolset: "gcc"
+            is-latest: true
+            name: "GCC 14: C++17-20 (shared)"
+            shared: true
+            build-type: "Release"
+            install: "zlib1g-dev"
+            build-cmake: true
+
+          - compiler: "gcc"
+            version: "14"
+            cxxstd: "17,20"
+            latest-cxxstd: "20"
+            cxx: "g++-14"
+            cc: "gcc-14"
+            runs-on: "ubuntu-latest"
+            container: "ubuntu:24.04"
+            b2-toolset: "gcc"
+            is-latest: true
+            name: "GCC 14: C++17-20 (shared, x86)"
+            shared: true
+            x86: true
+            build-type: "Release"
+            install: "gcc-14-multilib g++-14-multilib zlib1g-dev zlib1g-dev:i386"
+            build-cmake: true
+
+          - compiler: "gcc"
+            version: "14"
+            cxxstd: "17,20"
+            latest-cxxstd: "20"
+            cxx: "g++-14"
+            cc: "gcc-14"
+            runs-on: "ubuntu-latest"
+            container: "ubuntu:24.04"
+            b2-toolset: "gcc"
+            is-latest: true
+            name: "GCC 14: C++17-20 (asan)"
+            asan: true
+            build-type: "RelWithDebInfo"
+            install: "zlib1g-dev"
+
+          - compiler: "gcc"
+            version: "14"
+            cxxstd: "17,20"
+            latest-cxxstd: "20"
+            cxx: "g++-14"
+            cc: "gcc-14"
+            runs-on: "ubuntu-latest"
+            container: "ubuntu:24.04"
+            b2-toolset: "gcc"
+            is-latest: true
+            name: "GCC 14: C++17-20 (asan, x86)"
+            asan: true
+            x86: true
+            build-type: "RelWithDebInfo"
+            install: "gcc-14-multilib g++-14-multilib zlib1g-dev zlib1g-dev:i386"
+
+          - compiler: "gcc"
+            version: "14"
+            cxxstd: "17,20"
+            latest-cxxstd: "20"
+            cxx: "g++-14"
+            cc: "gcc-14"
+            runs-on: "ubuntu-latest"
+            container: "ubuntu:24.04"
+            b2-toolset: "gcc"
+            is-latest: true
+            name: "GCC 14: C++17-20 (ubsan)"
+            ubsan: true
+            build-type: "RelWithDebInfo"
+            install: "zlib1g-dev"
+
+          - compiler: "gcc"
+            version: "14"
+            cxxstd: "17,20"
+            latest-cxxstd: "20"
+            cxx: "g++-14"
+            cc: "gcc-14"
+            runs-on: "ubuntu-latest"
+            container: "ubuntu:24.04"
+            b2-toolset: "gcc"
+            is-latest: true
+            name: "GCC 14: C++17-20 (ubsan, x86)"
+            ubsan: true
+            x86: true
+            build-type: "RelWithDebInfo"
+            install: "gcc-14-multilib g++-14-multilib zlib1g-dev zlib1g-dev:i386"
 
           - compiler: "gcc"
             version: "13"
@@ -238,11 +367,9 @@ jobs:
             runs-on: "ubuntu-latest"
             container: "ubuntu:23.04"
             b2-toolset: "gcc"
-            is-latest: true
-            name: "GCC 13: C++17-20 (x86)"
-            x86: true
+            name: "GCC 13: C++17-20"
             build-type: "Release"
-            install: "gcc-13-multilib g++-13-multilib zlib1g-dev zlib1g-dev:i386"
+            install: "zlib1g-dev"
 
           - compiler: "gcc"
             version: "13"
@@ -260,101 +387,6 @@ jobs:
             cxxflags: "--coverage -fprofile-arcs -ftest-coverage"
             ccflags: "--coverage -fprofile-arcs -ftest-coverage"
             install: "lcov zlib1g-dev wget unzip"
-
-          - compiler: "gcc"
-            version: "13"
-            cxxstd: "17,20"
-            latest-cxxstd: "20"
-            cxx: "g++-13"
-            cc: "gcc-13"
-            runs-on: "ubuntu-latest"
-            container: "ubuntu:23.04"
-            b2-toolset: "gcc"
-            is-latest: true
-            name: "GCC 13: C++17-20 (shared)"
-            shared: true
-            build-type: "Release"
-            install: "zlib1g-dev"
-            build-cmake: true
-
-          - compiler: "gcc"
-            version: "13"
-            cxxstd: "17,20"
-            latest-cxxstd: "20"
-            cxx: "g++-13"
-            cc: "gcc-13"
-            runs-on: "ubuntu-latest"
-            container: "ubuntu:23.04"
-            b2-toolset: "gcc"
-            is-latest: true
-            name: "GCC 13: C++17-20 (shared, x86)"
-            shared: true
-            x86: true
-            build-type: "Release"
-            install: "gcc-13-multilib g++-13-multilib zlib1g-dev zlib1g-dev:i386"
-            build-cmake: true
-
-          - compiler: "gcc"
-            version: "13"
-            cxxstd: "17,20"
-            latest-cxxstd: "20"
-            cxx: "g++-13"
-            cc: "gcc-13"
-            runs-on: "ubuntu-latest"
-            container: "ubuntu:23.04"
-            b2-toolset: "gcc"
-            is-latest: true
-            name: "GCC 13: C++17-20 (asan)"
-            asan: true
-            build-type: "RelWithDebInfo"
-            install: "zlib1g-dev"
-
-          - compiler: "gcc"
-            version: "13"
-            cxxstd: "17,20"
-            latest-cxxstd: "20"
-            cxx: "g++-13"
-            cc: "gcc-13"
-            runs-on: "ubuntu-latest"
-            container: "ubuntu:23.04"
-            b2-toolset: "gcc"
-            is-latest: true
-            name: "GCC 13: C++17-20 (asan, x86)"
-            asan: true
-            x86: true
-            build-type: "RelWithDebInfo"
-            install: "gcc-13-multilib g++-13-multilib zlib1g-dev zlib1g-dev:i386"
-
-          - compiler: "gcc"
-            version: "13"
-            cxxstd: "17,20"
-            latest-cxxstd: "20"
-            cxx: "g++-13"
-            cc: "gcc-13"
-            runs-on: "ubuntu-latest"
-            container: "ubuntu:23.04"
-            b2-toolset: "gcc"
-            is-latest: true
-            name: "GCC 13: C++17-20 (ubsan)"
-            ubsan: true
-            build-type: "RelWithDebInfo"
-            install: "zlib1g-dev"
-
-          - compiler: "gcc"
-            version: "13"
-            cxxstd: "17,20"
-            latest-cxxstd: "20"
-            cxx: "g++-13"
-            cc: "gcc-13"
-            runs-on: "ubuntu-latest"
-            container: "ubuntu:23.04"
-            b2-toolset: "gcc"
-            is-latest: true
-            name: "GCC 13: C++17-20 (ubsan, x86)"
-            ubsan: true
-            x86: true
-            build-type: "RelWithDebInfo"
-            install: "gcc-13-multilib g++-13-multilib zlib1g-dev zlib1g-dev:i386"
 
           - compiler: "gcc"
             version: "12"
@@ -462,46 +494,46 @@ jobs:
             install: "zlib1g-dev"
 
           - compiler: "clang"
-            version: "17"
+            version: "18"
             cxxstd: "17,20"
             latest-cxxstd: "20"
-            cxx: "clang++-17"
-            cc: "clang-17"
+            cxx: "clang++-18"
+            cc: "clang-18"
             runs-on: "ubuntu-latest"
-            container: "ubuntu:23.10"
+            container: "ubuntu:24.04"
             b2-toolset: "clang"
             is-latest: true
-            name: "Clang 17: C++17-20"
+            name: "Clang 18: C++17-20"
             build-type: "Release"
             install: "zlib1g-dev"
             build-cmake: true
 
           - compiler: "clang"
-            version: "17"
+            version: "18"
             cxxstd: "17,20"
             latest-cxxstd: "20"
-            cxx: "clang++-17"
-            cc: "clang-17"
+            cxx: "clang++-18"
+            cc: "clang-18"
             runs-on: "ubuntu-latest"
-            container: "ubuntu:23.10"
+            container: "ubuntu:24.04"
             b2-toolset: "clang"
             is-latest: true
-            name: "Clang 17: C++17-20 (x86)"
+            name: "Clang 18: C++17-20 (x86)"
             x86: true
             build-type: "Release"
             install: "gcc-multilib g++-multilib zlib1g-dev zlib1g-dev:i386"
 
           - compiler: "clang"
-            version: "17"
+            version: "18"
             cxxstd: "20"
             latest-cxxstd: "20"
-            cxx: "clang++-17"
-            cc: "clang-17"
+            cxx: "clang++-18"
+            cc: "clang-18"
             runs-on: "ubuntu-latest"
-            container: "ubuntu:23.10"
+            container: "ubuntu:24.04"
             b2-toolset: "clang"
             is-latest: true
-            name: "Clang 17: C++20 (time-trace)"
+            name: "Clang 18: C++20 (time-trace)"
             time-trace: true
             build-type: "Release"
             cxxflags: "-ftime-trace"
@@ -509,32 +541,63 @@ jobs:
             install: "zlib1g-dev wget unzip"
 
           - compiler: "clang"
-            version: "17"
+            version: "18"
             cxxstd: "17,20"
             latest-cxxstd: "20"
-            cxx: "clang++-17"
-            cc: "clang-17"
+            cxx: "clang++-18"
+            cc: "clang-18"
             runs-on: "ubuntu-latest"
-            container: "ubuntu:23.10"
+            container: "ubuntu:24.04"
             b2-toolset: "clang"
             is-latest: true
-            name: "Clang 17: C++17-20 (asan)"
+            name: "Clang 18: C++17-20 (asan)"
             asan: true
             build-type: "RelWithDebInfo"
             install: "zlib1g-dev"
 
           - compiler: "clang"
-            version: "17"
+            version: "18"
             cxxstd: "17,20"
             latest-cxxstd: "20"
-            cxx: "clang++-17"
-            cc: "clang-17"
+            cxx: "clang++-18"
+            cc: "clang-18"
             runs-on: "ubuntu-latest"
-            container: "ubuntu:23.10"
+            container: "ubuntu:24.04"
             b2-toolset: "clang"
             is-latest: true
-            name: "Clang 17: C++17-20 (asan, x86)"
+            name: "Clang 18: C++17-20 (asan, x86)"
             asan: true
+            x86: true
+            build-type: "RelWithDebInfo"
+            install: "gcc-multilib g++-multilib zlib1g-dev zlib1g-dev:i386"
+
+          - compiler: "clang"
+            version: "18"
+            cxxstd: "17,20"
+            latest-cxxstd: "20"
+            cxx: "clang++-18"
+            cc: "clang-18"
+            runs-on: "ubuntu-latest"
+            container: "ubuntu:24.04"
+            b2-toolset: "clang"
+            is-latest: true
+            name: "Clang 18: C++17-20 (ubsan)"
+            ubsan: true
+            build-type: "RelWithDebInfo"
+            install: "zlib1g-dev"
+
+          - compiler: "clang"
+            version: "18"
+            cxxstd: "17,20"
+            latest-cxxstd: "20"
+            cxx: "clang++-18"
+            cc: "clang-18"
+            runs-on: "ubuntu-latest"
+            container: "ubuntu:24.04"
+            b2-toolset: "clang"
+            is-latest: true
+            name: "Clang 18: C++17-20 (ubsan, x86)"
+            ubsan: true
             x86: true
             build-type: "RelWithDebInfo"
             install: "gcc-multilib g++-multilib zlib1g-dev zlib1g-dev:i386"
@@ -548,27 +611,9 @@ jobs:
             runs-on: "ubuntu-latest"
             container: "ubuntu:23.10"
             b2-toolset: "clang"
-            is-latest: true
-            name: "Clang 17: C++17-20 (ubsan)"
-            ubsan: true
-            build-type: "RelWithDebInfo"
+            name: "Clang 17: C++17-20"
+            build-type: "Release"
             install: "zlib1g-dev"
-
-          - compiler: "clang"
-            version: "17"
-            cxxstd: "17,20"
-            latest-cxxstd: "20"
-            cxx: "clang++-17"
-            cc: "clang-17"
-            runs-on: "ubuntu-latest"
-            container: "ubuntu:23.10"
-            b2-toolset: "clang"
-            is-latest: true
-            name: "Clang 17: C++17-20 (ubsan, x86)"
-            ubsan: true
-            x86: true
-            build-type: "RelWithDebInfo"
-            install: "gcc-multilib g++-multilib zlib1g-dev zlib1g-dev:i386"
 
           - compiler: "clang"
             version: "16"
@@ -740,16 +785,16 @@ jobs:
             install: "zlib1g-dev"
 
           - compiler: "clang"
-            version: "^3.8"
+            version: "3.9"
             cxxstd: "11"
             latest-cxxstd: "11"
-            cxx: "clang++-3.8"
-            cc: "clang-3.8"
+            cxx: "clang++-3.9"
+            cc: "clang-3.9"
             runs-on: "ubuntu-latest"
-            container: "ubuntu:16.04"
+            container: "ubuntu:18.04"
             b2-toolset: "clang"
             is-earliest: true
-            name: "Clang ^3.8: C++11"
+            name: "Clang 3.9: C++11"
             build-type: "Release"
             install: "zlib1g-dev"
 
@@ -761,6 +806,10 @@ jobs:
     timeout-minutes: 120
 
     steps:
+      - name: Enable Node 16
+        run: |
+          echo "ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true" >> $GITHUB_ENV
+
       - name: Clone Boost.HTTP.Proto
         uses: actions/checkout@v3
         with:
@@ -887,6 +936,7 @@ jobs:
           cxxflags: ${{ (matrix.asan && '-fsanitize-address-use-after-scope -fsanitize=pointer-subtract') || '' }}
           user-config: ${{ (startsWith(matrix.runs-on, 'windows') && !matrix.skip-zlib && format('{0}/user-config.jam', steps.patch.outputs.workspace_root)) || '' }}
           stop-on-error: true
+          extra-args: ${{ (matrix.valgrind && 'testing.launcher=valgrind' || '' )}}
 
       - name: Boost CMake Workflow
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.2

--- a/include/boost/http_proto/parser.hpp
+++ b/include/boost/http_proto/parser.hpp
@@ -386,28 +386,30 @@ private:
 
     context& ctx_;
     parser_service& svc_;
+
     detail::workspace ws_;
     detail::header h_;
-    std::uint64_t body_avail_;
-    std::uint64_t body_total_;
-    std::uint64_t payload_remain_;
+    std::uint64_t body_avail_ = 0;
+    std::uint64_t body_total_ = 0;
+    std::uint64_t payload_remain_ = 0;
     std::size_t chunk_remain_ = 0;
-    std::size_t nprepare_;
+    std::size_t nprepare_ = 0;
 
     buffers::flat_buffer fb_;
     buffers::circular_buffer cb0_;
     buffers::circular_buffer cb1_;
-    buffers::circular_buffer* body_buf_;
     buffers::mutable_buffer_pair mbp_;
-    buffers::any_dynamic_buffer* eb_;
-    filter* filt_;
-    sink* sink_;
 
-    state st_;
-    how how_;
-    bool got_eof_;
+    buffers::circular_buffer* body_buf_ = nullptr;
+    buffers::any_dynamic_buffer* eb_ = nullptr;
+    filter* filt_ = nullptr;
+    sink* sink_ = nullptr;
+
+    state st_ = state::start;
+    how how_ = how::in_place;
+    bool got_eof_ = false;
 //    bool need_more_;
-    bool head_response_;
+    bool head_response_ = false;;
     bool needs_chunk_close_ = false;
 };
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1396,11 +1396,11 @@ body() const noexcept
         }
         auto cbp = body_buf_->data();
         BOOST_ASSERT(cbp[1].size() == 0);
-        BOOST_ASSERT(cbp[0].size() >= body_avail_);
+        BOOST_ASSERT(cbp[0].size() == body_avail_);
         return core::string_view(
             static_cast<char const*>(
                 cbp[0].data()),
-            cbp[0].size());
+            body_avail_);
     }
 }
 


### PR DESCRIPTION
OSX and other platforms hit assertion failures because we were reading a non-initialized data member.

First order of business is making the assert() more strict so more platforms consistently fail on CI. Second order of business is to fix this at its root: just use NSDMI. The initialization routines in http-proto are too complex to track so it's easier to fix this at inception.

The third and final order of business is to get the chunked parsing routines to properly update the `body_avail_` data member, which it wasn't doing before.