### PR TITLE
fix incorrect size calculation when headers are complete

### DIFF
--- a/include/boost/http_proto/parser.hpp
+++ b/include/boost/http_proto/parser.hpp
@@ -395,9 +395,18 @@ private:
     std::size_t chunk_remain_ = 0;
     std::size_t nprepare_ = 0;
 
+    // used to store initial headers + any potential overread
     buffers::flat_buffer fb_;
+
+    // used for raw input once headers are read
     buffers::circular_buffer cb0_;
+
+    // used for transformed output, if applicable
+    // can be empty/null
     buffers::circular_buffer cb1_;
+
+    // used to provide stable storage when returning
+    // `mutable_buffers_type` from relevant functions
     buffers::mutable_buffer_pair mbp_;
 
     buffers::circular_buffer* body_buf_ = nullptr;


### PR DESCRIPTION
Fixing the `flat_buffer` has caused a latent implementation bug to surface in the parser tests. Namely:
```cpp
{
    // Content-Length, in_place limit
    response_parser::config cfg;
    core::string_view const h =
        "HTTP/1.1 200 OK\r\n"
        "Content-Length: 10\r\n"
        "\r\n";
    cfg.headers.max_size = h.size();
    cfg.min_buffer = 3;
    check_in_place(cfg, true,
        error::in_place_overflow, false, {
        h, "1234567890" });
}
```
This test will pass when it should fail with the above `in_place_overflow` error. This is caused by an underflow on unsigned integers, which results in a wrap-around and `n0` winds up being the unsigned equivalent of `-33` which is actually quite large in unsigned.

The code most likely meant `fb_.max_size()` when it did this check and we've updated it to include an assertion for the purposes of saftey.