### PR TITLE
parser: two-phase parsing

### DIFF
--- a/doc/modules/ROOT/pages/design_requirements/parser.adoc
+++ b/doc/modules/ROOT/pages/design_requirements/parser.adoc
@@ -49,6 +49,31 @@ significant computational resources. For example:
   chunk directly after the current without having to perform memory movement
   due to the existence of a chunk header.
 
+== Two-Phase Parsing  
+
+The parser must return immediately after parsing the header and must not process
+the body until the next `parse()` call. For bodiless messages and head
+responses, it must transition directly to the `complete_in_place` state after
+parsing the header, making further `parse()` calls unnecessary (but still
+valid).
+
+This two-phase parsing offers several benefits with almost no complications on
+the API usage side:
+
+- It provides an optimization opportunity for users who want to attach a body
+  immediately after parsing the header (which is often the case), as there is no
+  need to allocate an internal buffer for the message body. This allows all
+  available space to be used for the input buffer.
+- Since parsing the body might result in an error, returning after parsing the
+  header enables users to access the header and, on the next `parse()` call,
+  encounter the error.
+- Setting the body limit during or after parsing the body doesn’t make much
+  sense, so returning immediately after parsing the header provides a window for
+  setting such limits.
+- If users attach a body immediately after parsing the header, we avoid the
+  need for an extra buffer copy operation (in case the user wants to attach an
+  elastic buffer).
+
 == Use Cases and Interfaces
 
 To keep things simple, we will use the following synchronous free functions to
@@ -57,38 +82,55 @@ demonstrate the flow of the parse operation in each example:
 [source,cpp]
 ----
 void
-read_some(stream& s, parser& pr)
+read_some(stream& s, parser& pr, error_code& ec)
 {
-    system::error_code ec;
-    if(pr.need_data())
-    {
-        auto n = s.read_some(pr.prepare(), ec);
-        pr.commit(n);
-        if(ec == asio::error::eof)
-        {
-            pr.commit_eof();
-            ec = {};
-        }
-        if(ec.failed())
-            throw system::system_error{ec};
-    }
     pr.parse(ec);
-    if(ec.failed() && ec != condition::need_more_input)
-        throw system::system_error{ec};
+    if(ec != condition::need_more_input)
+        return;
+
+    auto n = s.read_some(pr.prepare(), ec);
+    pr.commit(n);
+    if(ec == asio::error::eof)
+    {
+        pr.commit_eof();
+        ec = {};
+    }
+    else if(ec.failed())
+    {
+        return;
+    }
+
+    pr.parse(ec);
 }
 
 void
 read_header(stream& s, parser& pr)
 {
-    while(!pr.got_header())
-        read_some(s, pr);
+    do
+    {
+        error_code ec;
+        read_some(s, pr, ec);
+        if(ec == condition::need_more_input)
+            continue;
+        if(ec.failed())
+            throw system::system_error(ec);
+    }
+    while(! pr.got_header());
 }
 
 void
 read(stream& s, parser& pr)
-{
-    while(!pr.is_complete())
-        read_some(s, pr);
+{      
+    do
+    {
+        error_code ec;
+        read_some(s, pr, ec);
+        if(ec == condition::need_more_input)
+            continue;
+        if(ec.failed())
+            throw system::system_error(ec);
+    }
+    while(! pr.is_complete());
 }
 ----
 

--- a/include/boost/http_proto/header_limits.hpp
+++ b/include/boost/http_proto/header_limits.hpp
@@ -43,7 +43,9 @@ struct header_limits
             @li <a href="https://datatracker.ietf.org/doc/html/rfc9112#section-2.1"
                 >2.1.  Message Format (rfc9112)</a>
             @li <a href="https://datatracker.ietf.org/doc/html/rfc9112#section-5"
-                >5.  Field Syntax (rfc9112)</a>
+                >5.  Field Syntax (rfc9112)</a>@see
+            @li <a href="https://stackoverflow.com/questions/686217/maximum-on-http-header-values"
+                >Maximum on HTTP header values (Stackoverflow)</a>
     */
     std::size_t max_size = 8 * 1024;
 

--- a/include/boost/http_proto/parser.hpp
+++ b/include/boost/http_proto/parser.hpp
@@ -187,29 +187,25 @@ public:
         return st_ >= state::complete_in_place;
     }
 
+#if 0
     /** Returns `true` if the end of the stream was reached.
 
         The end of the stream is encountered
-        when one of the following conditions
-        occurs:
-
-        @li @ref commit_eof was called and there
-            is no more data left to parse, or
-
-        @li An unrecoverable error occurred
-            during parsing.
+        when @ref commit_eof was called and there
+        is no more data left to parse.
 
         When the end of stream is reached, the
-            function @ref reset must be called
-            to start parsing a new stream.
+        function @ref reset must be called
+        to start parsing a new stream.
     */
     bool
     is_end_of_stream() const noexcept
     {
         return
-            st_ == state::reset ||
-            (st_ >= state::complete_in_place && got_eof_);
+            got_eof_ &&
+            (st_ == state::reset || st_ >= state::complete_in_place);
     }
+#endif
 
     //--------------------------------------------
     //

--- a/include/boost/http_proto/parser.hpp
+++ b/include/boost/http_proto/parser.hpp
@@ -323,6 +323,19 @@ public:
     Sink&
     set_body(Args&&... args);
 
+    /** Sets the maximum allowed size of the body for the current message.
+
+        This overrides the default value specified by
+        @ref config_base::body_limit.
+        The limit automatically resets to the default
+        for the next message.
+
+        @param n The new body size limit in bytes.
+    */
+    BOOST_HTTP_PROTO_DECL
+    void
+    set_body_limit(std::uint64_t n);
+
     /** Return the available body data.
 
         The returned buffer span will be invalidated if any member
@@ -369,9 +382,6 @@ private:
     bool
     is_plain() const noexcept;
 
-    void
-    on_headers(system::error_code&);
-
     BOOST_HTTP_PROTO_DECL
     void
     on_set_body() noexcept;
@@ -382,6 +392,9 @@ private:
         std::size_t,
         bool);
 
+    std::uint64_t
+    body_limit_remain() const noexcept;
+
     static constexpr unsigned buffers_N = 8;
 
     enum class state
@@ -389,6 +402,7 @@ private:
         reset,
         start,
         header,
+        header_done,
         body,
         set_body,
         complete_in_place,
@@ -407,10 +421,11 @@ private:
 
     detail::workspace ws_;
     detail::header h_;
-    std::size_t body_avail_ = 0;
+    std::uint64_t body_limit_= 0;
     std::uint64_t body_total_ = 0;
     std::uint64_t payload_remain_ = 0;
     std::uint64_t chunk_remain_ = 0;
+    std::size_t body_avail_ = 0;
     std::size_t nprepare_ = 0;
 
     // used to store initial headers + any potential overread

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -921,7 +921,7 @@ parse(
             if(fb_.size() == 0)
             {
                 // stream closed cleanly
-                st_ = state::complete_in_place;
+                st_ = state::reset;
                 ec = BOOST_HTTP_PROTO_ERR(
                     error::end_of_stream);
                 return;

--- a/test/unit/parser.cpp
+++ b/test/unit/parser.cpp
@@ -221,6 +221,8 @@ struct parser_test
         , res_pr_(ctx_)
     {
         in_.reserve(5);
+        req_pr_.reset();
+        res_pr_.reset();
     }
 
     //-------------------------------------------
@@ -1245,8 +1247,7 @@ struct parser_test
     void
     start()
     {
-        if(pr_->is_end_of_stream())
-            pr_->reset();
+        pr_->reset();
         if(pr_ == &req_pr_)
             req_pr_.start();
         else
@@ -1265,6 +1266,7 @@ struct parser_test
         if(ec.failed())
         {
             BOOST_TEST_EQ(ec, ex);
+            pr_->reset();
             return;
         }
         if(pr_->is_complete())
@@ -1281,6 +1283,7 @@ struct parser_test
         if(ec.failed())
         {
             BOOST_TEST_EQ(ec, ex);
+            pr_->reset();
             return;
         }
         if(! BOOST_TEST(pr_->is_complete()))
@@ -1305,6 +1308,7 @@ struct parser_test
         if(ec.failed())
         {
             BOOST_TEST_EQ(ec, ex);
+            pr_->reset();
             return;
         }
         buffers::flat_buffer fb(buf, sizeof(buf));
@@ -1316,6 +1320,7 @@ struct parser_test
             if(ec.failed())
             {
                 BOOST_TEST_EQ(ec, ex);
+                pr_->reset();
                 return;
             }
             if(! BOOST_TEST(pr_->is_complete()))
@@ -1343,6 +1348,7 @@ struct parser_test
         if(ec.failed())
         {
             BOOST_TEST_EQ(ec, ex);
+            pr_->reset();
             return;
         }
         auto& ts = pr_->set_body<test_sink>();
@@ -1353,6 +1359,7 @@ struct parser_test
             if(ec.failed())
             {
                 BOOST_TEST_EQ(ec, ex);
+                pr_->reset();
                 return;
             }
             if(! BOOST_TEST(pr_->is_complete()))

--- a/test/unit/parser.cpp
+++ b/test/unit/parser.cpp
@@ -1278,7 +1278,6 @@ struct parser_test
             BOOST_TEST_EQ(pr_->body(), sb_);
             return;
         }
-        BOOST_TEST(pr_->body().empty());
         read(*pr_, in, ec);
         if(ec.failed())
         {
@@ -1313,7 +1312,6 @@ struct parser_test
         }
         buffers::flat_buffer fb(buf, sizeof(buf));
         pr_->set_body(std::ref(fb));
-        BOOST_TEST(pr_->body().empty());
         if(! pr_->is_complete())
         {
             read(*pr_, in, ec);
@@ -1328,7 +1326,6 @@ struct parser_test
         }
         BOOST_TEST_EQ(
             test_to_string(fb.data()), sb_);
-        BOOST_TEST(pr_->body().empty());
         // this should be a no-op
         read(*pr_, in, ec);
         BOOST_TEST(! ec.failed());
@@ -1352,7 +1349,6 @@ struct parser_test
             return;
         }
         auto& ts = pr_->set_body<test_sink>();
-        BOOST_TEST(pr_->body().empty());
         if(! pr_->is_complete())
         {
             read(*pr_, in, ec);
@@ -1366,7 +1362,6 @@ struct parser_test
                 return;
         }
         BOOST_TEST_EQ(ts.s, sb_);
-        BOOST_TEST(pr_->body().empty());
         // this should be a no-op
         read(*pr_, in, ec);
         BOOST_TEST(! ec.failed());

--- a/test/unit/zlib.cpp
+++ b/test/unit/zlib.cpp
@@ -551,7 +551,9 @@ struct zlib_test
 
             boost::system::error_code ec;
             pr.parse(ec);
-            if( ec )
+            if(!ec)
+                pr.parse(ec);
+            if(ec)
                 BOOST_TEST(ec == error::in_place_overflow
                     || ec == error::need_data);
 
@@ -739,6 +741,7 @@ struct zlib_test
             }
 
             pr.start();
+            pr.set_body_limit(body_size);
 
             auto rs = receiver(
                 pr,
@@ -798,6 +801,9 @@ struct zlib_test
         pr.commit_eof();
 
         boost::system::error_code ec;
+        pr.parse(ec);
+        BOOST_TEST(! ec.failed());
+        BOOST_TEST(pr.got_header());
         pr.parse(ec);
         BOOST_TEST_EQ(ec, zlib::error::version_err);
     }


### PR DESCRIPTION
With the new changes, the parser returns immediately after the header is parsed and does not begin parsing the body until the next call to `parse()`. In the case of bodiless messages and head responses, it directly transitions to the `complete_in_place` state after the header is parsed, making a call to `parse()` unnecessary (but still valid).

This two-phase parsing brings a few benefits with almost no complications on the usage side of the API:

- It introduces an optimization opportunity for users who want to attach a body. If they do so immediately after the header is parsed (which seems to be the case most of the time), there's no need for `cb1_` for elastic bodies and a small `cb1_` for sink bodies (as it will be used temporarily). This means all the extra space can be utilized for `cb0_`.
- Because parsing the body might complete with an error, returning after the header is parsed allows users to access the header and on the next call to parse encounter the error.
- Setting the body limit in the middle of parsing the body or after it doesn't make much sense, so returning right after the header is parsed provides a window for setting such limits.
- If users want to attach a body, they will almost always do so immediately after the header is parsed. By not continuing the parsing of the body, we avoid the need for an extra buffer copy operation (in case the user wants to attach a buffer).