### PR TITLE
Use Boost namespaced targets in CMakeLists

### DIFF
--- a/doc/mrdocs.yml
+++ b/doc/mrdocs.yml
@@ -34,6 +34,7 @@ base-url: https://www.github.com/cppalliance/http_proto/blob/develop/
 verbose: true
 multipage: true
 use-system-libc: true
+use-system-stdlib: true
 
 # Warnings
 warn-unnamed-param: true

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -28,16 +28,16 @@ target_include_directories(boost_http_proto_tests PRIVATE . ../../../url/extra/t
 target_include_directories(boost_http_proto_tests PRIVATE . ../../)
 target_link_libraries(
     boost_http_proto_tests PRIVATE
-    boost_http_proto
-    boost_filesystem
+    Boost::http_proto
+    Boost::filesystem
     )
 
-if (TARGET boost_rts_zlib)
-    target_link_libraries(boost_http_proto_tests PRIVATE boost_rts_zlib)
+if (TARGET Boost::rts_zlib)
+    target_link_libraries(boost_http_proto_tests PRIVATE Boost::rts_zlib)
 endif ()
 
-if (TARGET boost_rts_brotli)
-    target_link_libraries(boost_http_proto_tests PRIVATE boost_rts_brotli)
+if (TARGET Boost::rts_brotli)
+    target_link_libraries(boost_http_proto_tests PRIVATE Boost::rts_brotli)
 endif ()
 
 add_test(NAME boost_http_proto_tests COMMAND boost_http_proto_tests)


### PR DESCRIPTION
Without Boost namespace, the superproject cannot resolve dependencies from subdirectory CMakeLists:
https://github.com/boostorg/cmake/pull/86