### PR TITLE
Use <utility> instead of <functional> for std::reference_wrapper on C++20+

### DIFF
--- a/include/boost/http_proto/detail/type_traits.hpp
+++ b/include/boost/http_proto/detail/type_traits.hpp
@@ -10,7 +10,11 @@
 #ifndef BOOST_HTTP_PROTO_DETAIL_TYPE_TRAITS_HPP
 #define BOOST_HTTP_PROTO_DETAIL_TYPE_TRAITS_HPP
 
+#if __cplusplus >= 202002L
+#include <utility>
+#else
 #include <functional>
+#endif
 #include <type_traits>
 
 namespace boost {


### PR DESCRIPTION
For C++20 and later, std::reference_wrapper is available in <utility>, which is a lighter-weight header than <functional>.

Fixes #210

Generated with [Claude Code](https://claude.ai/code)