### PR TITLE
io_buffer_param is in Boost.Corosio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(BOOST_HTTP_DEPENDENCIES
     Boost::capy
     Boost::config
     Boost::core
+    Boost::corosio
     Boost::json
     Boost::mp11
     Boost::static_assert

--- a/build/Jamfile
+++ b/build/Jamfile
@@ -43,6 +43,7 @@ lib boost_http
    : http_sources
    : requirements
      <library>/boost//capy
+     <library>/boost/corosio//boost_corosio
      <library>/boost/json//boost_json/<warnings-as-errors>off
      <library>/boost//url
      <include>../
@@ -51,6 +52,7 @@ lib boost_http
      <target-os>darwin:<linkflags>"-framework Security"
    : usage-requirements
      <library>/boost//capy
+     <library>/boost/corosio//boost_corosio
      <library>/boost/json//boost_json/<warnings-as-errors>off
      <library>/boost//url
      <target-os>windows:<library>bcrypt_sys

--- a/include/boost/http/server/route_handler.hpp
+++ b/include/boost/http/server/route_handler.hpp
@@ -12,7 +12,7 @@
 
 #include <boost/http/detail/config.hpp>
 #include <boost/http/server/router_types.hpp>
-#include <boost/capy/buffers/buffer_param.hpp>
+#include <boost/corosio/io_buffer_param.hpp>
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/datastore.hpp>
 #include <boost/capy/task.hpp>
@@ -242,7 +242,7 @@ struct BOOST_HTTP_SYMBOL_VISIBLE
     route_task
     write(Buffers const& buffers)
     {
-        return write_impl(capy::buffer_param(buffers));
+        return write_impl(corosio::io_buffer_param(buffers));
     }
 
     /** Complete a streaming response.
@@ -284,7 +284,7 @@ protected:
 
         @return A task that completes when the write is done.
     */
-    virtual route_task write_impl(capy::buffer_param buffers) = 0;
+    virtual route_task write_impl(corosio::io_buffer_param buffers) = 0;
 };
 
 } // http

--- a/test/unit/server/test_route_handler.hpp
+++ b/test/unit/server/test_route_handler.hpp
@@ -24,7 +24,7 @@ struct test_route_params : route_params
         co_return {};
     }
 
-    route_task write_impl(capy::buffer_param) override
+    route_task write_impl(corosio::io_buffer_param) override
     {
         co_return {};
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Boost::corosio as a new project dependency.

* **Refactor**
  * Updated internal buffer handling mechanism for improved performance.

* **Tests**
  * Updated unit tests to align with internal buffer changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->