### PR TITLE
Sync capy changes

### DIFF
--- a/include/boost/http/bcrypt.hpp
+++ b/include/boost/http/bcrypt.hpp
@@ -41,6 +41,7 @@
 #include <boost/system/error_code.hpp>
 #include <boost/system/is_error_code_enum.hpp>
 
+#include <boost/capy/continuation.hpp>
 #include <boost/capy/task.hpp>
 #include <boost/capy/ex/executor_ref.hpp>
 #include <boost/capy/ex/io_env.hpp>
@@ -524,6 +525,7 @@ struct hash_async_op
     version ver_;
     result result_;
     std::exception_ptr ep_;
+    capy::continuation cont_;
 
     bool await_ready() const noexcept
     {
@@ -534,21 +536,22 @@ struct hash_async_op
         std::coroutine_handle<void> cont,
         capy::io_env const* env)
     {
+        cont_.h = cont;
         auto caller_ex = env->executor;
         auto& pool = capy::get_system_context();
         auto sys_ex = pool.get_executor();
         capy::run_async(sys_ex,
-            [this, cont, caller_ex]
+            [this, caller_ex]
             (result r) mutable
             {
                 result_ = r;
-                caller_ex.dispatch(cont).resume();
+                caller_ex.dispatch(cont_).resume();
             },
-            [this, cont, caller_ex]
+            [this, caller_ex]
             (std::exception_ptr ep) mutable
             {
                 ep_ = ep;
-                caller_ex.dispatch(cont).resume();
+                caller_ex.dispatch(cont_).resume();
             }
         )(hash_task(password_, rounds_, ver_));
     }
@@ -567,6 +570,7 @@ struct compare_async_op
     hash_buf hash_str_;
     bool result_ = false;
     std::exception_ptr ep_;
+    capy::continuation cont_;
 
     bool await_ready() const noexcept
     {
@@ -577,21 +581,22 @@ struct compare_async_op
         std::coroutine_handle<void> cont,
         capy::io_env const* env)
     {
+        cont_.h = cont;
         auto caller_ex = env->executor;
         auto& pool = capy::get_system_context();
         auto sys_ex = pool.get_executor();
         capy::run_async(sys_ex,
-            [this, cont, caller_ex]
+            [this, caller_ex]
             (bool ok) mutable
             {
                 result_ = ok;
-                caller_ex.dispatch(cont).resume();
+                caller_ex.dispatch(cont_).resume();
             },
-            [this, cont, caller_ex]
+            [this, caller_ex]
             (std::exception_ptr ep) mutable
             {
                 ep_ = ep;
-                caller_ex.dispatch(cont).resume();
+                caller_ex.dispatch(cont_).resume();
             }
         )(compare_task(password_, hash_str_));
     }

--- a/include/boost/http/json/json_sink.hpp
+++ b/include/boost/http/json/json_sink.hpp
@@ -60,7 +60,7 @@ class json_sink
     capy::immediate<capy::io_result<std::size_t>>
     write_impl(CB const& buffers, bool eof)
     {
-        system::error_code ec;
+        std::error_code ec;
         std::size_t total = 0;
         auto const end = capy::end(buffers);
         for(auto it = capy::begin(buffers); it != end; ++it)
@@ -71,14 +71,14 @@ class json_sink
                 buf.size(),
                 ec);
             total += n;
-            if(ec.failed())
-                return {ec, total};
+            if(ec)
+                return capy::ready(ec, total);
         }
         if(eof)
         {
             parser_.finish(ec);
-            if(ec.failed())
-                return {ec, total};
+            if(ec)
+                return capy::ready(ec, total);
         }
         return capy::ready(total);
     }
@@ -188,11 +188,11 @@ public:
     capy::immediate<capy::io_result<>>
     write_eof()
     {
-        system::error_code ec;
+        std::error_code ec;
         parser_.finish(ec);
-        if(ec.failed())
-            return {ec};
-        return {};
+        if(ec)
+            return capy::ready(ec);
+        return capy::ready();
     }
 
     /** Check if parsing is complete.

--- a/test/unit/bcrypt.cpp
+++ b/test/unit/bcrypt.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/http/bcrypt.hpp>
 
+#include <boost/capy/continuation.hpp>
 #include <boost/capy/ex/execution_context.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/ex/system_context.hpp>
@@ -50,14 +51,14 @@ struct test_executor
     void on_work_started() const noexcept {}
     void on_work_finished() const noexcept {}
 
-    std::coroutine_handle<> dispatch(std::coroutine_handle<void> h) const
+    std::coroutine_handle<> dispatch(capy::continuation& c) const
     {
-        return h;
+        return c.h;
     }
 
-    void post(std::coroutine_handle<void> h) const
+    void post(capy::continuation& c) const
     {
-        h.resume();
+        c.h.resume();
     }
 };
 

--- a/test/unit/json/json_sink.cpp
+++ b/test/unit/json/json_sink.cpp
@@ -13,6 +13,7 @@
 #include <boost/capy/buffers.hpp>
 #include <boost/capy/buffers/make_buffer.hpp>
 #include <boost/capy/concept/write_sink.hpp>
+#include <boost/capy/continuation.hpp>
 #include <boost/capy/ex/execution_context.hpp>
 #include <boost/capy/ex/run_async.hpp>
 #include <boost/capy/io_result.hpp>
@@ -67,16 +68,16 @@ struct test_executor
     void on_work_started() const noexcept {}
     void on_work_finished() const noexcept {}
 
-    std::coroutine_handle<> dispatch(std::coroutine_handle<void> h) const
+    std::coroutine_handle<> dispatch(capy::continuation& c) const
     {
         if(dispatch_count_)
             ++(*dispatch_count_);
-        return h;
+        return c.h;
     }
 
-    void post(std::coroutine_handle<void> h) const
+    void post(capy::continuation& c) const
     {
-        h.resume();
+        c.h.resume();
     }
 };
 


### PR DESCRIPTION
Upstream introduced capy::continuation as the executor-facing schedulable unit, so executors now take continuation& in dispatch and post. io_result also tightened to std::error_code. Update the bcrypt async ops to hold a continuation member and dispatch through it, and switch json_sink to std::error_code at the io_result boundary. Test executors updated to match the new concept.